### PR TITLE
Change Netlify URL domain to `.netlify.app` to avoid redirections

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,14 +3,14 @@ const github = require("@actions/github");
 const axios = require("axios");
 
 const waitForUrl = async (url, MAX_TIMEOUT) => {
-  const iterations = MAX_TIMEOUT / 2;
+  const iterations = MAX_TIMEOUT / 3;
   for (let i = 0; i < iterations; i++) {
     try {
       await axios.get(url);
       return;
     } catch (e) {
       console.log("Url unavailable, retrying...");
-      await new Promise(r => setTimeout(r, 2000));
+      await new Promise(r => setTimeout(r, 3000));
     }
   }
   core.setFailed(`Timeout reached: Unable to connect to ${url}`);
@@ -24,7 +24,7 @@ const run = async () => {
     if (!siteName) {
       core.setFailed("Required field `site_name` was not provided");
     }
-    const url = `https://${commit}--${siteName}.netlify.com`;
+    const url = `https://${commit}--${siteName}.netlify.app`;
     core.setOutput("url", url);
     console.log(`Waiting for a 200 from: ${url}`);
     await waitForUrl(url, MAX_TIMEOUT);


### PR DESCRIPTION
This changes the test URL returned from the action to end in `.netlify.app` instead of `.netlify.com`, [due to this change at Netlify](https://community.netlify.com/t/changes-coming-to-netlify-site-urls/8918). 

Previously the `.com` URL was causing my lighthouse CI reports to emit an extra warning:

> There were issues affecting this run of Lighthouse: The page may not be loading as expected because your test URL (https://xxx.netlify.com/) was redirected to https://xxx.netlify.app/. Try testing the second URL directly.

Note: this PR also reduces the poll frequency slightly, it seemed unnecessarily high to me 😬 )